### PR TITLE
When using Hibernate from ITest javax.validation needs to be on the classpath

### DIFF
--- a/extension/other/jpa/fabric3-hibernate-library/build.gradle
+++ b/extension/other/jpa/fabric3-hibernate-library/build.gradle
@@ -12,6 +12,8 @@ dependencies {
 
     compile group: 'concurrent', name: 'concurrent', version: concurrentVersion
 
+    compile group: 'javax.validation', name: 'validation-api', version: '1.1.0.Final'
+
     // add the SPI and Util modules to provided so they are not included in the contribution
     providedCompile project(':kernel:api:fabric3-spi')
     providedCompile project(':kernel:impl:fabric3-util')


### PR DESCRIPTION
This adds validation-api so that the EntityManager can be used within ITests. This arose when using the hibernate and spring profiles together.
